### PR TITLE
[FIX] avoid redundant default dir creation

### DIFF
--- a/src/iiif_download/config.py
+++ b/src/iiif_download/config.py
@@ -56,9 +56,6 @@ class Config:
         # Initialize from environment variables if present
         self._load_from_env()
 
-        # Create directories if they don't exist
-        self._create_dirs()
-
     def _load_from_env(self):
         """Load configuration from environment variables."""
         if path := os.getenv("IIIF_BASE_DIR"):
@@ -104,11 +101,6 @@ class Config:
             self._proxy_settings["https"] = https_proxy
 
         # TODO add is_logged, semaphore, user_agent, save_manifest
-
-    def _create_dirs(self):
-        """Create necessary directories if they don't exist."""
-        self._img_dir.mkdir(parents=True, exist_ok=True)
-        self._log_dir.mkdir(parents=True, exist_ok=True)
 
     def set_path(
         self, path: Optional[Union[str, Path]] = None, base_dir: Optional[Union[str, Path]] = None

--- a/src/iiif_download/tests/test_config.py
+++ b/src/iiif_download/tests/test_config.py
@@ -104,10 +104,11 @@ def test_config_env_override():
 
 
 def test_config_directory_creation():
-    """Test that config creates necessary directories"""
+    """Test that env-driven path settings create their directories via the setter."""
     test_base = Path("/tmp/iiif_test")
     os.environ["IIIF_BASE_DIR"] = str(test_base)
     os.environ["IIIF_IMG_DIR"] = "test_img"
+    os.environ["IIIF_LOG_DIR"] = "test_log"
 
     config = Config()
 
@@ -115,12 +116,15 @@ def test_config_directory_creation():
     assert config.img_dir.exists()
     assert config.log_dir.exists()
     assert config.img_dir.name == "test_img"
+    assert config.log_dir.name == "test_log"
 
     # Cleanup
     import shutil
 
     shutil.rmtree(test_base)
     del os.environ["IIIF_BASE_DIR"]
+    del os.environ["IIIF_IMG_DIR"]
+    del os.environ["IIIF_LOG_DIR"]
 
 
 def test_proxy_settings():


### PR DESCRIPTION
When `-d /custom/path` was passed, `Config.__init__` was still creating `cwd/img` (and `cwd/log`) via `_create_dirs()` before the CLI overrode `img_dir`. Both setters (`set_path`) and `Logger.__init__` already call `mkdir()` lazily at the resolved location, so the eager call was redundant. Therefore, I removed `_create_dirs()` and updated `test_config_directory_creation` to drive both dirs through env-triggered setters.
